### PR TITLE
Remove 'relationship = enemy' from Agroprom squad description

### DIFF
--- a/gamedata/configs/misc/squad_descr_agroprom.ltx
+++ b/gamedata/configs/misc/squad_descr_agroprom.ltx
@@ -112,7 +112,6 @@ faction = bandit
 npc = sim_default_bandit_2, sim_default_bandit_2, sim_default_bandit_2, sim_default_bandit_2, sim_default_bandit_3
 target_smart = agr_smart_terrain_2_3
 sympathy = 0.1
-relationship = enemy
 ;on_death = %+agr_smart_terrain_2_3_bandits_1_squad_death%
 
 [agr_smart_terrain_2_3_bandits_1_squad_attack]
@@ -121,14 +120,12 @@ npc = sim_default_bandit_2, sim_default_bandit_2, sim_default_bandit_2, sim_defa
 target_smart = {+agr_stalker_base_start_attack_3} agr_smart_terrain_4_4_near_2, agr_smart_terrain_2_3
 attack_power = 400
 sympathy = 0.1
-relationship = enemy
 
 [agr_smart_terrain_6_4_bandits_1_squad]
 faction = bandit
 npc = sim_default_bandit_2, sim_default_bandit_2, sim_default_bandit_2, sim_default_bandit_2, sim_default_bandit_3
 target_smart = agr_smart_terrain_6_4
 sympathy = 0.1
-relationship = enemy
 ;on_death = %+agr_smart_terrain_6_4_bandits_1_squad_death%
 
 [agr_smart_terrain_6_4_bandits_1_squad_attack]


### PR DESCRIPTION
As I previously said in #33, there are two bandit squads on Agroprom, that sometimes send bonus squads to capture loners' base. 

In vanilla their relationship was set to enemy, however, it could've been neutral when you have more than average reputation with bandits (1000+). SRP fixed the issue of predefined relationship being ignored in some scenarios, however, apart from useful cases (when it prevented the game from breaking the storyline, like during Lefty quest), there are cases when that change made some squads hostile toward player.

While some of these are quite reasonable, such as, for example, Limansk bandits, where the disposition high enough made completing the quest easy as pie, I believe particularly this one is clearly an oversight since the squad is aggressive even when the player is a bandit himself and even if he gets a quest on clearing their road.