### PR TITLE
Removed vid_restart at changing texture quality

### DIFF
--- a/gamedata/configs/ui/ui_mm_opt.xml
+++ b/gamedata/configs/ui/ui_mm_opt.xml
@@ -445,7 +445,7 @@
 		</cap_texture_lod>
 
 		<track_texture_lod x="194" y="10" width="245" height="21" invert="1" step="1" is_integer="1">
-			<options_item entry="texture_lod" group="mm_opt_video_adv" depend="vid"/>
+			<options_item entry="texture_lod" group="mm_opt_video_adv" depend="restart"/>
 		</track_texture_lod>
 
 		<cap_aniso x="20" y="10" width="143" height="21">

--- a/gamedata/configs/ui/ui_mm_opt_16.xml
+++ b/gamedata/configs/ui/ui_mm_opt_16.xml
@@ -456,7 +456,7 @@
 		</cap_texture_lod>
 
 		<track_texture_lod x="162" y="10" width="200" height="21" invert="1" step="1" is_integer="1">
-			<options_item entry="texture_lod" group="mm_opt_video_adv" depend="vid"/>
+			<options_item entry="texture_lod" group="mm_opt_video_adv" depend="restart"/>
 		</track_texture_lod>
 
 		<cap_aniso x="17" y="10" width="119" height="21">


### PR DESCRIPTION
Fixed the game renderer restarting after changing texture settings even though there is no need to do so. The changes won't be applied until restarting the game anyways.