### PR TITLE
Make the 'Return to Yar' quest fail on daybreak to match the behaviour of 'Get the PDA' quest and Yar's description of it

### DIFF
--- a/gamedata/configs/misc/tm_darkvalley.ltx
+++ b/gamedata/configs/misc/tm_darkvalley.ltx
@@ -350,7 +350,6 @@ prior = 11
 name = val_night_bloodsucker_reward_name
 text = val_night_bloodsucker_reward_text
 condlist_0 = {+val_night_bloodsucker_reward_complete} complete
-condlist_1 = {+val_night_bloodsucker_fail} fail
 reward_money = 2000
 immediate_reward = true
 target_story_ids = 1123

--- a/gamedata/configs/misc/tm_darkvalley.ltx
+++ b/gamedata/configs/misc/tm_darkvalley.ltx
@@ -350,6 +350,7 @@ prior = 11
 name = val_night_bloodsucker_reward_name
 text = val_night_bloodsucker_reward_text
 condlist_0 = {+val_night_bloodsucker_reward_complete} complete
+condlist_1 = {+val_night_bloodsucker_fail} fail
 reward_money = 2000
 immediate_reward = true
 target_story_ids = 1123

--- a/gamedata/configs/scripts/darkvalley/val_sr_quest_night_bloodsucker.ltx
+++ b/gamedata/configs/scripts/darkvalley/val_sr_quest_night_bloodsucker.ltx
@@ -1,0 +1,15 @@
+[logic]
+active = sr_idle
+
+[sr_idle]
+on_info = {+val_night_bloodsucker_started} sr_idle@3 %=give_inited_task(storyline:val_night_bloodsucker:freedom)%
+
+[sr_idle@3]
+on_info = {=is_day} nil %+val_night_bloodsucker_fail%
+on_info2 = {+val_night_bloodsucker_complete} sr_idle@4 %=give_inited_task(storyline:val_night_bloodsucker_reward:freedom)%
+
+[sr_idle@4]
+on_info = {+val_night_bloodsucker_reward_complete} nil
+on_info2 = {=is_day} nil %+val_night_bloodsucker_fail%
+
+


### PR DESCRIPTION
Fix for #7.