### PR TITLE
Fixed sim_eliminate_resource_smart quest never activating

### DIFF
--- a/gamedata/configs/misc/tm_sim.ltx
+++ b/gamedata/configs/misc/tm_sim.ltx
@@ -132,7 +132,7 @@ prior = 3
 [sim_eliminate_smart]
 type = eliminate_smart
 task_type = additional
-target_cond = true
+target_cond = {!target_resource_smart !target_path_smart} true, false
 name = sim_eliminate_smart
 text = sim_eliminate_smart_text
 reward_money = 500


### PR DESCRIPTION
In the original game, when the point to capture is target_resource_smart ('resource' or 'territory' points), the game is supposed to give the player a different quest that sim_eliminate_smart. It works fine with sim_eliminate_path_smart (which has a different name - "Clear the road" - and description - "Help the friendly squad get through"), however, for whatever reason, it does not work with sim_eliminate_resource_smart (which has the same name but a different description - "Chase the enemy away from the area. This will weaken him.")

This commit fixes that issue.

![image](https://user-images.githubusercontent.com/35204405/88079727-ca669c80-cb86-11ea-8ccc-a3d338be3a9c.png)
